### PR TITLE
Use os.Stat instead of os.Open & f.Stat

### DIFF
--- a/gawp.go
+++ b/gawp.go
@@ -241,8 +241,9 @@ func handleEvent(e fsnotify.Event) error {
 	s, err := os.Stat(e.Name)
 
 	if err != nil {
+		// file is already removed
 		if os.IsNotExist(err) {
-			return nil
+			return watcher.Remove(e.Name)
 		}
 		return err
 	}

--- a/gawp.go
+++ b/gawp.go
@@ -238,15 +238,14 @@ func handleEvent(e fsnotify.Event) error {
 		return nil
 	}
 
-	h, err := os.Open(e.Name)
+	s, err := os.Stat(e.Name)
 
 	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
 		return err
 	}
-
-	defer h.Close()
-
-	s, err := h.Stat()
 
 	if err != nil {
 		return err


### PR DESCRIPTION
On windows, `os.Stat` always failed for deleting because the event is called after deleting.
