### PR TITLE
Use current working directory as base, not directory of executable.

### DIFF
--- a/gawp.go
+++ b/gawp.go
@@ -73,11 +73,8 @@ func main() {
 	flag.Parse()
 	log.SetFlags(log.Ldate | log.Lmicroseconds)
 
-	dir, err := filepath.Abs(filepath.Dir(os.Args[0]))
-
-	if err != nil {
-		log.Fatal(err)
-	}
+	var err error
+	dir := "."
 
 	defer logFile.Close()
 


### PR DESCRIPTION
When installed via `go get`, the configuration file in the current directory was not being used. It was looking for the file in the same directory as the executable.

``` bash
$ pwd
/tmp/gawp
$ ls -lh $(pwd)/.gawp
-rw-r--r-- 1 myuser mygroup 184 Feb 13 14:14 /tmp/gawp/.gawp
$ gawp
2015/02/13 14:15:08.978551 unable to load configuration file: .gawp (open /my/gopath/bin/.gawp: The system cannot find the file specified.)
```

This change simply using the relative `this` for the base directory.
