### PR TITLE
Fix error by removing lock file not being closed.

### DIFF
--- a/gawp.go
+++ b/gawp.go
@@ -93,6 +93,10 @@ func main() {
 	}
 
 	defer func() {
+		if err := lock.Close(); err != nil {
+			log.Println(err)
+		}
+
 		if err := os.Remove(lock.Name()); err != nil {
 			log.Println(err)
 		}


### PR DESCRIPTION
A lock file is not closed before being removed. If gawp is run on Windows, it will cause an error like below.

1. Run gawp

```
C:\Users\USERNAME\SOME_PROJECT>gawp
2015/11/27 00:10:28.648911 started Gawp
```

2. Type Ctrl-C (os.Remove fails)

```
2015/11/27 00:10:29.468072 remove C:\Users\USERNAME\AppData\Local\Temp/gawp-y9lhbx7j36ey.lock: The process cannot access the file because it is being used by another process.
```

3. Rerun gawp (the lock file hasn't be removed)

```
C:\Users\USERNAME\SOME_PROJECT>gawp
2015/11/27 00:10:31.676845 unable to lock active directory: open C:\Users\USERNAME\AppData\Local\Temp/gawp-y9lhbx7j36ey.lock: The file exists.
```
